### PR TITLE
pathValue(...): Return 'undefined', instead of a run-time error, when path is not found

### DIFF
--- a/node_modules/jsonQ/jsonQ.js
+++ b/node_modules/jsonQ/jsonQ.js
@@ -994,15 +994,15 @@
         pathValue: function(json, path) {
             var i = 0,
 
-                ln = path.length;
+            ln = path.length;
 
-            if (json === null) {
-                return null;
+            if ((json === null) || (json === undefined)) {
+                return json;
             }
             while (i < ln) {
-                if (json[path[i]] === null) {
-                    json = null;
-                    return;
+                if ((json[path[i]] === null) || (json[path[i]] === undefined)) {
+                    json = json[path[i]];
+                    return json;
                 } else {
                     json = json[path[i]];
                 }


### PR DESCRIPTION
Hi s-yadav,

Thanks for writing jsonQ!  I like the concept, and think this library is very helpful.

I noticed that, at least when running jsonQ in a node.js environment, I get a run-time error if I call the "pathValue" function when requesting a path that doesn't exist.

I made a small change so that `undefined` is returned instead.

For example,

```
const testObj = { apple: "fresh", vegetables: { carrot: "red", tomato: "orange" }}
console.log(jsonQ(testObj).pathValue(["colors", "blue"]))
```

Originally, jsonQ would throw an error in the second line.  With the change I am proposing, jsonQ would return `undefined` instead.

What do you think?

Thanks,
jayyuen1
